### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Check maven for latest versions of this library. At present, this library has be
 Adding this library autoconfigures an instance of [Haystack Tracer](https://github.com/ExpediaDotCom/haystack-client-java/blob/opentracing-spring-haystack-starter/core/src/main/java/com/expedia/www/haystack/client/Tracer.java) using defaults mentioned below. 
 
 * `service-name`: Is read from configuration property `spring.application.name`. If it is not provided then the value will be set to `unnamed-application`
-* `dispatcher`: Spans are dispatched to Haystack using one or more [Dispatcher](https://github.com/ExpediaDotCom/haystack-client-java/blob/opentracing-spring-haystack-starter/core/src/main/java/com/expedia/www/haystack/client/dispatchers/Dispatcher.java) instances. If none is configured or created, then a [LoggerDispatcher](https://github.com/ExpediaDotCom/haystack-client-java/blob/opentracing-spring-haystack-starter/core/src/main/java/com/expedia/www/haystack/client/dispatchers/LoggerDispatcher.java) is configured with "haystack" as the logger name
+* `dispatcher`: Spans are dispatched to Haystack using one or more [Dispatcher](https://github.com/ExpediaDotCom/haystack-client-java/blob/master/core/src/main/java/com/expedia/www/haystack/client/dispatchers/Dispatcher.java) instances. If none is configured or created, then a [LoggerDispatcher](https://github.com/ExpediaDotCom/haystack-client-java/blob/master/core/src/main/java/com/expedia/www/haystack/client/dispatchers/LoggerDispatcher.java) is configured with "haystack" as the logger name
 * `metrics`: This library depends on Micrometer's MeterRegistry to instrument the library itself. If no instance of `MeterRegistry` is present in the [spring application](https://spring.io/blog/2018/03/16/micrometer-spring-boot-2-s-new-application-metrics-collector#what-do-i-get-out-of-the-box), then it uses a built-in No-op implementation. Which means no metrics are recorded
 
 ### Configuration
@@ -193,7 +193,7 @@ opentracing.haystack.dispatchers.agent.keep-alive-without-calls=true
 opentracing.haystack.dispatchers.agent.negotiation-type=PLAINTEXT
 ```
 
-Alternately, one can create a bean of type [GrpcDispatcherFactory](https://github.com/ExpediaDotCom/haystack-client-java/blob/opentracing-spring-haystack-starter/integrations/opentracing-spring-haystack-starter/src/main/java/com/expedia/haystack/opentracing/spring/starter/support/GrpcDispatcherFactory.java). 
+Alternately, one can create a bean of type [GrpcDispatcherFactory](https://github.com/ExpediaDotCom/opentracing-spring-haystack-starter/blob/master/opentracing-spring-haystack-starter/src/main/java/com/expedia/haystack/opentracing/spring/starter/support/GrpcDispatcherFactory.java). 
 
 ```java
 public interface GrpcDispatcherFactory {
@@ -232,7 +232,7 @@ opentracing:
 
 `headers` property is optional. All properties defined under 'headers' will be sent as HTTP headers along with the serialized span data. 
 
-As in Grpc Agent, one can create a bean of type [HttpDispatcherFactory](https://github.com/ExpediaDotCom/haystack-client-java/blob/opentracing-spring-haystack-starter/integrations/opentracing-spring-haystack-starter/src/main/java/com/expedia/haystack/opentracing/spring/starter/support/GrpcDispatcherFactory.java). If available, that bean will be invoked to create a RemoteDispatcher with HttpClient
+As in Grpc Agent, one can create a bean of type [HttpDispatcherFactory](https://github.com/ExpediaDotCom/opentracing-spring-haystack-starter/blob/master/opentracing-spring-haystack-starter/src/main/java/com/expedia/haystack/opentracing/spring/starter/support/HttpDispatcherFactory.java). If available, that bean will be invoked to create a RemoteDispatcher with HttpClient
 
 ##### Dispatcher Bean
 


### PR DESCRIPTION
Fixes links to dispatchers.

Links were still referring to opentracing-spring-haystack-starter subdirectory under haystack-client-java, and opentracing-spring-haystack-starter has since moved out to this separate repository.